### PR TITLE
Tweak the trust flags, or it breaks with newer GHC/Cabal combinations

### DIFF
--- a/copilot-language.cabal
+++ b/copilot-language.cabal
@@ -68,8 +68,8 @@ library
 
     -fpackage-trust
     -- Trusted packages:
-    -trust base
-    -trust containers
-    -trust array
+    -trust=base
+    -trust=containers
+    -trust=array
 
 


### PR DESCRIPTION
I have GHC 7.10.1 and Cabal 1.22.2.0. With that combination, the flags as originally specified produce the command line:

```
"-fwarn-tabs" "-auto-all" "-caf-all" "-Wall" "-fpackage-trust" "base" "containers" "-trust" "array"
```

Note that it's lacking two `-trust` flags before `base` and `containers`, for reasons I cannot begin to fathom. By changing to put the explicit `=` in it goes through properly, and seems like a more robust formulation anyway.
